### PR TITLE
Use OpenSSL's optimized SHA256_Transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,19 @@ Transport layer:
 ---------------
 
 The dnet network is used as transport layer.
+
+
+Updates:
+---------------
+
+Replacement SHA256 transform code from openssl project
+modified by true ( XDAG rvKaJSbP9DE6sg6XetYtSpaK+2aDbUq8 )
+
+50-150% speedup on Intel Core series post-Nehalem
+50-100% speedup on AMD Heavy Equipment cores
+400-500% speedup on Ryzen
+Better use of threads than reference implementation
+
+Heat output is increased with the fast version, so you
+may want to continue using the old implementation on
+devices with poor cooling (notebooks, etc).

--- a/README.md
+++ b/README.md
@@ -119,14 +119,12 @@ The dnet network is used as transport layer.
 Updates:
 ---------------
 
-Replacement SHA256 transform code from openssl project
+Replacement SHA256 transform code from openssl project,
 modified by true ( XDAG rvKaJSbP9DE6sg6XetYtSpaK+2aDbUq8 )
 
-50-150% speedup on Intel Core series post-Nehalem
-50-100% speedup on AMD Heavy Equipment cores
-400-500% speedup on Ryzen
-Better use of threads than reference implementation
+- 50-150% speedup on Intel Core series post-Nehalem
+- 50-100% speedup on AMD Heavy Equipment cores
+- 400-500% speedup on Ryzen
+- Better use of threads than reference implementation
 
-Heat output is increased with the fast version, so you
-may want to continue using the old implementation on
-devices with poor cooling (notebooks, etc).
+Heat output is increased with the fast version, so you may want to continue using the old implementation on devices with poor cooling (notebooks, etc).

--- a/cheatcoin/Makefile
+++ b/cheatcoin/Makefile
@@ -78,7 +78,7 @@ headers = \
 	$(ldusinc)/rbtree.h				\
 
 
-flags = -std=gnu11 -O3 -DDFSTOOLS -DCHEATCOIN -DNDEBUG -g -lpthread -lcrypto -lm -Wall -Wmissing-prototypes -Wl,--export-dynamic
+flags = -std=gnu11 -O3 -DDFSTOOLS -DCHEATCOIN -DNDEBUG -g -lpthread -lcrypto -lm -Wall -Wmissing-prototypes -Wno-unused-result -Wl,--export-dynamic
 
 
 all: xdag
@@ -86,8 +86,11 @@ all: xdag
 xdag: $(sources) $(headers) Makefile
 	gcc -o xdag $(sources) $(flags)
 
+xdagfast:
+	gcc -o xdagfast $(sources) -DSHA256_USE_OPENSSL_TXFM $(flags)
+
 clean:
-	rm xdag
+	rm xdag xdagfast
 
 install: xdag
 	sudo cp xdag /usr/local/bin/xdag

--- a/cheatcoin/hash.c
+++ b/cheatcoin/hash.c
@@ -5,7 +5,7 @@
 #include "hash.h"
 
 void cheatcoin_hash(void *data, size_t size, cheatcoin_hash_t hash) {
-	SHA256_CTX ctx;
+	SHA256REF_CTX ctx;
 	sha256_init(&ctx);
 	sha256_update(&ctx, data, size);
 	sha256_final(&ctx, (uint8_t *)hash);
@@ -15,21 +15,21 @@ void cheatcoin_hash(void *data, size_t size, cheatcoin_hash_t hash) {
 }
 
 unsigned cheatcoin_hash_ctx_size(void) {
-	return sizeof(SHA256_CTX);
+	return sizeof(SHA256REF_CTX);
 }
 
 void cheatcoin_hash_init(void *ctxv) {
-	SHA256_CTX *ctx = (SHA256_CTX *)ctxv;
+	SHA256REF_CTX *ctx = (SHA256REF_CTX *)ctxv;
 	sha256_init(ctx);
 }
 
 void cheatcoin_hash_update(void *ctxv, void *data, size_t size) {
-	SHA256_CTX *ctx = (SHA256_CTX *)ctxv;
+	SHA256REF_CTX *ctx = (SHA256REF_CTX *)ctxv;
 	sha256_update(ctx, data, size);
 }
 
 void cheatcoin_hash_final(void *ctxv, void *data, size_t size, cheatcoin_hash_t hash) {
-	SHA256_CTX ctx;
+	SHA256REF_CTX ctx;
 	memcpy(&ctx, ctxv, sizeof(ctx));
 	sha256_update(&ctx, (uint8_t *)data, size);
 	sha256_final(&ctx, (uint8_t *)hash);
@@ -39,7 +39,7 @@ void cheatcoin_hash_final(void *ctxv, void *data, size_t size, cheatcoin_hash_t 
 }
 
 uint64_t cheatcoin_hash_final_multi(void *ctxv, uint64_t *nonce, int attempts, int step, cheatcoin_hash_t hash) {
-	SHA256_CTX ctx;
+	SHA256REF_CTX ctx;
 	cheatcoin_hash_t hash0;
 	uint64_t min_nonce = 0;
 	int i;
@@ -60,12 +60,12 @@ uint64_t cheatcoin_hash_final_multi(void *ctxv, uint64_t *nonce, int attempts, i
 }
 
 void cheatcoin_hash_get_state(void *ctxv, cheatcoin_hash_t state) {
-	SHA256_CTX *ctx = (SHA256_CTX *)ctxv;
+	SHA256REF_CTX *ctx = (SHA256REF_CTX *)ctxv;
 	memcpy(state, ctx->state, sizeof(cheatcoin_hash_t));
 }
 
 void cheatcoin_hash_set_state(void *ctxv, cheatcoin_hash_t state, size_t size) {
-	SHA256_CTX *ctx = (SHA256_CTX *)ctxv;
+	SHA256REF_CTX *ctx = (SHA256REF_CTX *)ctxv;
 	memcpy(ctx->state, state, sizeof(cheatcoin_hash_t));
 	ctx->datalen = 0;
 	ctx->bitlen = size << 3;

--- a/cheatcoin/sha256.c
+++ b/cheatcoin/sha256.c
@@ -29,6 +29,7 @@
 #define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
 
 /**************************** VARIABLES *****************************/
+#ifndef SHA256_USE_OPENSSL_TXFM
 static const WORD k[64] = {
 	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
 	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
@@ -41,7 +42,7 @@ static const WORD k[64] = {
 };
 
 /*********************** FUNCTION DEFINITIONS ***********************/
-static void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+static void sha256_transform(SHA256REF_CTX *ctx, const BYTE data[])
 {
 	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
@@ -82,7 +83,13 @@ static void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
 	ctx->state[7] += h;
 }
 
-void sha256_init(SHA256_CTX *ctx)
+#else
+	#include <openssl/sha.h>
+	
+	#define sha256_transform(x,y)	SHA256_Transform((SHA256_CTX *)x, y)
+#endif
+
+void sha256_init(SHA256REF_CTX *ctx)
 {
 	ctx->datalen = 0;
 	ctx->bitlen = 0;
@@ -96,7 +103,7 @@ void sha256_init(SHA256_CTX *ctx)
 	ctx->state[7] = 0x5be0cd19;
 }
 
-void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
+void sha256_update(SHA256REF_CTX *ctx, const BYTE data[], size_t len)
 {
 	WORD i;
 
@@ -111,7 +118,7 @@ void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
 	}
 }
 
-void sha256_final(SHA256_CTX *ctx, BYTE hash[])
+void sha256_final(SHA256REF_CTX *ctx, BYTE hash[])
 {
 	WORD i;
 

--- a/cheatcoin/sha256.h
+++ b/cheatcoin/sha256.h
@@ -20,15 +20,15 @@ typedef unsigned char BYTE;             // 8-bit byte
 typedef unsigned int  WORD;             // 32-bit word, change to "long" for 16-bit machines
 
 typedef struct {
-	BYTE data[64];
-	WORD datalen;
-	unsigned long long bitlen;
 	WORD state[8];
-} SHA256_CTX;
+	unsigned long long bitlen;
+	BYTE data[64];
+	WORD datalen, extra;	
+} SHA256REF_CTX;
 
 /*********************** FUNCTION DECLARATIONS **********************/
-void sha256_init(SHA256_CTX *ctx);
-void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len);
-void sha256_final(SHA256_CTX *ctx, BYTE hash[]);
+void sha256_init(SHA256REF_CTX *ctx);
+void sha256_update(SHA256REF_CTX *ctx, const BYTE data[], size_t len);
+void sha256_final(SHA256REF_CTX *ctx, BYTE hash[]);
 
 #endif   // SHA256_H


### PR DESCRIPTION
The reference sha256 implementation included in xdag is similar in structure to OpenSSL. However there are some implementation differences I think regarding reuse of uninitialized buffers in the reference implementation and I could not directly swap out the entirety of the algo. I was able to directly replace sha256_transform with OpenSSL's SHA256_Transform.

To make this a direct swap, I changed the organization of the SHA256_CTX struct, renamed the struct to avoid naming conflict, and added a #define to choose which implementation to use.

With higher efficiency comes higher heat, so mobile devices should still use the slow version, thus the rationale for having choice.